### PR TITLE
Replace service account JSON with workload identity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,8 @@ jobs:
     permissions:
       pull-requests: write # for FirebaseExtended/action-hosting-deploy to comment on PRs
       checks: write # for FirebaseExtended/action-hosting-deploy to comment on PRs
+      contents: "read" # for google-github-actions/auth
+      id-token: "write" # for google-github-actions/auth
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,16 +111,30 @@ jobs:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: ${{ env.FLUTTER_CHANNEL }}
 
+      - id: "auth"
+        uses: "google-github-actions/auth@v2"
+        env:
+          PROJECT_ID: ankigpt-prod
+          PROJECT_NUMBER: 41416187582
+        with:
+          workload_identity_provider: "projects/${{ env.PROJECT_NUMBER }}/locations/global/workloadIdentityPools/github/providers/github-provider"
+          service_account: "github-action-644087301@${{ env.PROJECT_ID }}.iam.gserviceaccount.com"
+
+      # From https://github.com/FirebaseExtended/action-hosting-deploy/issues/174#issuecomment-1312272238
+      - name: Set SERVICE_ACCOUNT_KEY to environment variables
+        run: |
+          echo "SERVICE_ACCOUNT_KEY=$(cat "${{ steps.auth.outputs.credentials_file_path }}" | tr -d '\n')" >> $GITHUB_ENV
+
       - name: Build
         run: |
           flutter build web \
             --web-renderer canvaskit \
             --dart-define=RELEASE_DATE="$(date +"%B %e %Y")" \
-            --dart-define=FLAVOR="dev"
+            --dart-define=FLAVOR="prod"
 
       - uses: FirebaseExtended/action-hosting-deploy@120e124148ab7016bec2374e5050f15051255ba2
         with:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
-          firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_ANKIGPT_PROD }}"
+          firebaseServiceAccount: "${{ env.SERVICE_ACCOUNT_KEY }}"
           projectId: ankigpt-prod
           target: ankigpt-app

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,15 +30,17 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       checks: write # for FirebaseExtended/action-hosting-deploy
+      contents: "read" # for google-github-actions/auth
+      id-token: "write" # for google-github-actions/auth
     strategy:
       matrix:
         environment:
           - name: prod
-            firebaseServiceAccount: FIREBASE_SERVICE_ACCOUNT_ANKIGPT_PROD
+            projectNumber: 41416187582
             projectId: ankigpt-prod
             flavor: prod
           - name: dev
-            firebaseServiceAccount: FIREBASE_SERVICE_ACCOUNT_ANKIGPT_DEV
+            projectNumber: 531541464051
             projectId: ankigpt-dev
             flavor: dev
     steps:
@@ -59,10 +61,21 @@ jobs:
             --dart-define=RELEASE_DATE="$(date +"%B %e %Y")" \
             --dart-define=FLAVOR="${{ matrix.environment.flavor }}"
 
+      - id: "auth"
+        uses: "google-github-actions/auth@v2"
+        with:
+          workload_identity_provider: "projects/${{ matrix.environment.projectNumber }}/locations/global/workloadIdentityPools/github/providers/github-provider"
+          service_account: "github-action-644087301@${{ matrix.environment.projectId }}.iam.gserviceaccount.com"
+
+      # From https://github.com/FirebaseExtended/action-hosting-deploy/issues/174#issuecomment-1312272238
+      - name: Set SERVICE_ACCOUNT_KEY to environment variables
+        run: |
+          echo "SERVICE_ACCOUNT_KEY=$(cat "${{ steps.auth.outputs.credentials_file_path }}" | tr -d '\n')" >> $GITHUB_ENV
+
       - uses: FirebaseExtended/action-hosting-deploy@120e124148ab7016bec2374e5050f15051255ba2
         with:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
-          firebaseServiceAccount: "${{ secrets[matrix.environment.firebaseServiceAccount] }}"
+          firebaseServiceAccount: "${{ env.SERVICE_ACCOUNT_KEY }}"
           channelId: live
           target: ankigpt-app
           projectId: "${{ matrix.environment.projectId }}"


### PR DESCRIPTION
```sh
PROJECT_ID=...
PROJECT_NUMBER=...

OWNER=nilsreichardt
# The repo name is case-sensitive
REPO=AnkiGPT

SERVICE_ACCOUNT_NAME=...

gcloud iam workload-identity-pools create "github" \
  --project="${PROJECT_ID}" \
  --location="global" \
  --display-name="GitHub pool"

gcloud iam workload-identity-pools providers create-oidc "github-provider" \
  --project="${PROJECT_ID}" \
  --location="global" \
  --workload-identity-pool="github" \
  --display-name="GitHub provider" \
  --attribute-mapping="google.subject=assertion.sub,attribute.actor=assertion.actor,attribute.aud=assertion.aud,attribute.repository=assertion.repository" \
  --issuer-uri="https://token.actions.githubusercontent.com"

gcloud iam service-accounts add-iam-policy-binding "${SERVICE_ACCOUNT_NAME}@${PROJECT_ID}.iam.gserviceaccount.com" \
  --project="${PROJECT_ID}" \
  --role="roles/iam.workloadIdentityUser" \
  --member="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/github/attribute.repository/${OWNER}/${REPO}"
```