### PR TITLE
Fixed bug that deleting & editing cards wasn't sent to the backend

### DIFF
--- a/lib/src/providers/clear_session_state_provider.dart
+++ b/lib/src/providers/clear_session_state_provider.dart
@@ -1,7 +1,4 @@
 import 'package:ankigpt/src/providers/cards_list_provider.dart';
-import 'package:ankigpt/src/providers/delete_card_provider.dart';
-import 'package:ankigpt/src/providers/edit_answer_provider.dart';
-import 'package:ankigpt/src/providers/edit_question_provider.dart';
 import 'package:ankigpt/src/providers/search_provider.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -15,8 +12,5 @@ class ClearSessionState extends _$ClearSessionState {
   void clear() {
     ref.read(cardsListProvider.notifier).clear();
     ref.read(searchQueryProvider.notifier).clear();
-    ref.read(editAnswerProvider.notifier).clear();
-    ref.read(editQuestionProvider.notifier).clear();
-    ref.read(deleteCardControllerProvider.notifier).clear();
   }
 }

--- a/lib/src/providers/clear_session_state_provider.g.dart
+++ b/lib/src/providers/clear_session_state_provider.g.dart
@@ -6,7 +6,7 @@ part of 'clear_session_state_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$clearSessionStateHash() => r'dc713288dcda7117a62c5a85d38ec74317b222a8';
+String _$clearSessionStateHash() => r'cfc0930b0cf370bbf72b849dc9fe00f030704b60';
 
 /// See also [ClearSessionState].
 @ProviderFor(ClearSessionState)

--- a/lib/src/providers/delete_card_provider.dart
+++ b/lib/src/providers/delete_card_provider.dart
@@ -100,12 +100,4 @@ class DeleteCardController extends _$DeleteCardController {
     ref.read(cardsListProvider.notifier).add(_lastDeletedCard!);
     return true;
   }
-
-  /// Clears the internal queue.
-  ///
-  /// This method clears the internal queue of pending deletion requests. It
-  /// should be called when the session is closed.
-  void clear() {
-    _queue.cancel();
-  }
 }

--- a/lib/src/providers/delete_card_provider.g.dart
+++ b/lib/src/providers/delete_card_provider.g.dart
@@ -7,7 +7,7 @@ part of 'delete_card_provider.dart';
 // **************************************************************************
 
 String _$deleteCardControllerHash() =>
-    r'ef2fb901fb97c64775bc776c42fc9788419fe4c6';
+    r'c4927f65610d31eb12210bca5bed0e04cdec5a59';
 
 /// `DeleteCardController` provides a mechanism to manage card deletions in an
 /// Anki session.

--- a/lib/src/providers/edit_answer_provider.dart
+++ b/lib/src/providers/edit_answer_provider.dart
@@ -51,9 +51,4 @@ class EditAnswer extends _$EditAnswer {
   void setDebounceDuration(Duration duration) {
     _debounceDuration = duration;
   }
-
-  void clear() {
-    EasyDebounce.cancel(_debounceKey);
-    _queue.cancel();
-  }
 }

--- a/lib/src/providers/edit_answer_provider.g.dart
+++ b/lib/src/providers/edit_answer_provider.g.dart
@@ -6,7 +6,7 @@ part of 'edit_answer_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$editAnswerHash() => r'422cb919c7881c73eef4f01bf181a73ead9046b3';
+String _$editAnswerHash() => r'b66418c8648f0e772590a89ca6c96b7239b18600';
 
 /// See also [EditAnswer].
 @ProviderFor(EditAnswer)

--- a/lib/src/providers/edit_question_provider.dart
+++ b/lib/src/providers/edit_question_provider.dart
@@ -51,9 +51,4 @@ class EditQuestion extends _$EditQuestion {
   void setDebounceDuration(Duration duration) {
     _debounceDuration = duration;
   }
-
-  void clear() {
-    EasyDebounce.cancel(_debounceKey);
-    _queue.cancel();
-  }
 }

--- a/lib/src/providers/edit_question_provider.g.dart
+++ b/lib/src/providers/edit_question_provider.g.dart
@@ -6,7 +6,7 @@ part of 'edit_question_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$editQuestionHash() => r'7e989a8e777328096b7673572d8b28c7384cce5d';
+String _$editQuestionHash() => r'f42e3efc00465d3b00f7665034db4824b12fb7ed';
 
 /// See also [EditQuestion].
 @ProviderFor(EditQuestion)

--- a/test/providers/delete_card_provider_test.dart
+++ b/test/providers/delete_card_provider_test.dart
@@ -222,8 +222,6 @@ void main() {
               sessionId: sessionId,
             );
 
-        container.read(deleteCardControllerProvider.notifier).clear();
-
         verifyNever(mockSessionRepository.deleteCard(
           sessionId: sessionId,
           cardId: card2.id,

--- a/test/providers/edit_answer_provider_test.dart
+++ b/test/providers/edit_answer_provider_test.dart
@@ -86,26 +86,5 @@ void main() {
         answer: 'second-Answer',
       ));
     });
-
-    test('.clear() should reset the provider', () async {
-      container.read(editAnswerProvider.notifier).setDebounceDuration(
-            const Duration(milliseconds: 1),
-          );
-
-      container.read(editAnswerProvider.notifier).debounce(
-            sessionId: 'sessionId',
-            cardId: 'cardId',
-            answer: 'answer',
-          );
-
-      // Wait for the debounce duration
-      await Future.delayed(const Duration(milliseconds: 1));
-
-      verifyNever(mockSessionRepository.editAnswer(
-        sessionId: 'sessionId',
-        cardId: 'cardId',
-        answer: 'answer',
-      ));
-    });
   });
 }

--- a/test/providers/edit_answer_provider_test.dart
+++ b/test/providers/edit_answer_provider_test.dart
@@ -98,8 +98,6 @@ void main() {
             answer: 'answer',
           );
 
-      container.read(editAnswerProvider.notifier).clear();
-
       // Wait for the debounce duration
       await Future.delayed(const Duration(milliseconds: 1));
 

--- a/test/providers/edit_question_provider_test.dart
+++ b/test/providers/edit_question_provider_test.dart
@@ -86,26 +86,5 @@ void main() {
         question: 'second-question',
       ));
     });
-
-    test('.clear() should reset the provider', () async {
-      container.read(editQuestionProvider.notifier).setDebounceDuration(
-            const Duration(milliseconds: 1),
-          );
-
-      container.read(editQuestionProvider.notifier).debounce(
-            sessionId: 'sessionId',
-            cardId: 'cardId',
-            question: 'question',
-          );
-
-      // Wait for the debounce duration
-      await Future.delayed(const Duration(milliseconds: 1));
-
-      verifyNever(mockSessionRepository.editQuestion(
-        sessionId: 'sessionId',
-        cardId: 'cardId',
-        question: 'question',
-      ));
-    });
   });
 }

--- a/test/providers/edit_question_provider_test.dart
+++ b/test/providers/edit_question_provider_test.dart
@@ -98,8 +98,6 @@ void main() {
             question: 'question',
           );
 
-      container.read(editQuestionProvider.notifier).clear();
-
       // Wait for the debounce duration
       await Future.delayed(const Duration(milliseconds: 1));
 


### PR DESCRIPTION
Cancelling the queues blocked further requests. Because the provider always keeps alive, cancelling the queues isn't required.

Fixes #99