### PR TITLE
Change Dependabot interval to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,11 +6,11 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
   - package-ecosystem: "pub"
     directory: "/"
     schedule:
-      interval: weekly
+      interval: monthly
     ignore:
       # Ignoring the Firebase dependencies because they require also updating
       # macos/Podfile and ios/Podfile (to apply the workaround for


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the scheduling intervals for Dependabot updates from weekly to monthly for GitHub Actions and Pub packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->